### PR TITLE
Only disable XML-RPC if the plugin is active

### DIFF
--- a/classes/wp-maintenance.php
+++ b/classes/wp-maintenance.php
@@ -35,10 +35,14 @@ class WP_maintenance {
             add_action( 'admin_init', array( &$this, 'wpm_process_settings_import') );
             add_action( 'admin_init', array( &$this, 'wpm_process_settings_export') );     
         }
-        // disabled XMLRPC
-        add_filter('xmlrpc_enabled', '__return_false');
-        /** Disable REST API **/
         $checkActive = get_option('wp_maintenance_active');
+
+        // disabled XMLRPC
+        if( isset($checkActive) && $checkActive == 1 ) {
+            add_filter('xmlrpc_enabled', '__return_false');
+        }
+
+        /** Disable REST API **/
         add_filter( 'rest_authentication_errors', function( $result ) {
             // If a previous authentication check was applied,
             // pass that result along without modification.


### PR DESCRIPTION
Hi - I develop an app that relies upon WordPress's XML-RPC API, and one of my customers who uses your plugin noticed it caused my app to fail. I investigated and determined it's because you're currently disabling XML-RPC all the time, even if the plugin is not active.